### PR TITLE
fix: handle undefined CallSite filenames

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ const stackChain = require('stack-chain');
 // and the hooks are expected to be completely transparent.
 stackChain.filter.attach(function (error, frames) {
   return frames.filter(function (callSite) {
-    return callSite.getFileName().slice(0, __dirname.length) !== __dirname;
+    const filename = callSite.getFileName();
+    return !(filename && filename.slice(0, __dirname.length) === __dirname);
   });
 });
 

--- a/test/test-stackfilter-eval.js
+++ b/test/test-stackfilter-eval.js
@@ -1,0 +1,8 @@
+'use strict';
+
+require('../');
+
+let e;
+eval('(function() { e = new Error(); })()');
+
+e.stack;


### PR DESCRIPTION
`getFileName()` can return `undefined`, such as a function defined using `eval`

(Ran into this with _sinon_, which [has been fixed](https://github.com/sinonjs/sinon/commit/fe6444e0667759aef60d088ed73babc2c12d684b) in an unreleased commit)
