### PR TITLE
Support new setupHooks argument format for Node versions v5.10  or later

### DIFF
--- a/async-hook.js
+++ b/async-hook.js
@@ -103,7 +103,12 @@ function AsyncHook() {
   }
 
   // setup async wrap
-  asyncWrap.setupHooks(this._hooks.init, this._hooks.pre, this._hooks.post, this._hooks.destroy);
+  asyncWrap.setupHooks({
+    init: this._hooks.init,
+    pre: this._hooks.pre,
+    post: this._hooks.post,
+    destroy: this._hooks.destroy
+  });
 }
 module.exports = AsyncHook;
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "cli-color": "1.1.x"
   },
   "engines": {
-    "node": "^5.7"
+    "node": "^5.10"
   }
 }


### PR DESCRIPTION
Happy to amend this however you want, but this keeps the test suite green and gets the library working with v5.10