### PR TITLE
Fix nexttick exception

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "devDependencies": {
     "async": "1.5.x",
-    "cli-color": "1.1.x"
+    "cli-color": "1.1.x",
+    "eslint": "^3.4.0"
   },
   "engines": {
     "node": "^4.5 || ^5.10 || ^6.0"

--- a/patches/next-tick.js
+++ b/patches/next-tick.js
@@ -33,9 +33,11 @@ module.exports = function patch() {
         callback.apply(this, arguments);
         didThrow = false;
       } finally {
-        // call the post hook, followed by the destroy hook
-        hooks.post.call(handle, uid, didThrow);
-        hooks.destroy.call(null, uid);
+        process.once('uncaughtException', function () {
+          // call the post hook, followed by the destroy hook
+          hooks.post.call(handle, uid, didThrow);
+          hooks.destroy.call(null, uid);
+        });
       }
     };
 

--- a/patches/next-tick.js
+++ b/patches/next-tick.js
@@ -32,8 +32,6 @@ module.exports = function patch() {
       try {
         callback.apply(this, arguments);
         didThrow = false;
-      } catch(e) {
-        throw e;
       } finally {
         // call the post hook, followed by the destroy hook
         hooks.post.call(handle, uid, didThrow);

--- a/patches/next-tick.js
+++ b/patches/next-tick.js
@@ -32,18 +32,13 @@ module.exports = function patch() {
       try {
         callback.apply(this, arguments);
         didThrow = false;
+      } catch(e) {
+        throw e;
       } finally {
-        if (didThrow) {
-          process.once('uncaughtException', function () {
-            hooks.post.call(handle, uid, true);
-            hooks.destroy.call(null, uid);
-          });
-        }
+        // call the post hook, followed by the destroy hook
+        hooks.post.call(handle, uid, didThrow);
+        hooks.destroy.call(null, uid);
       }
-
-      // call the post hook, followed by the destroy hook
-      hooks.post.call(handle, uid, false);
-      hooks.destroy.call(null, uid);
     };
 
     return oldNextTick.apply(process, args);

--- a/patches/next-tick.js
+++ b/patches/next-tick.js
@@ -33,14 +33,12 @@ module.exports = function patch() {
         callback.apply(this, arguments);
         didThrow = false;
       } finally {
-        if(didThrow) {
+        if(didThrow && process.listenerCount('uncaughtException') > 0) {
           // Callback throws and there is at least one listener for `uncaughtException` event, so that process won't quit abrutly.
-          if(process.listenerCount('uncaughtException') > 0) {
-            process.once('uncaughtException', function () {
-              hooks.post.call(handle, uid, true);
-              hooks.destroy.call(null, uid);
-            });
-          }
+          process.once('uncaughtException', function () {
+            hooks.post.call(handle, uid, true);
+            hooks.destroy.call(null, uid);
+          });
           // or, the process exits with non-zero status code and both `post` and `destroy` hooks won't be called.
         } else {
           // callback done successfully

--- a/patches/timers.js
+++ b/patches/timers.js
@@ -56,7 +56,7 @@ function patchTimer(hooks, state, setFn, clearFn, Handle, timerMap, singleCall) 
         callback.apply(this, arguments);
         didThrow = false;
       } finally {
-        if (didThrow) {
+        if (didThrow && process.listenerCount('uncaughtException') > 0) {
           process.once('uncaughtException', function () {
             // call the post hook
             hooks.post.call(handle, uid, true);

--- a/test/runner.js
+++ b/test/runner.js
@@ -40,8 +40,8 @@ function runTest(filename, done) {
 
   p.once('close', function (statusCode) {
     const ok = function () {
-      if(filename === 'test-nexttick-exception.js' && statusCode === 1) {
-        return true;
+      if(filename === 'test-nexttick-exception.js') {
+        return statusCode === 1;
       }
       return statusCode === 0;
     }();

--- a/test/runner.js
+++ b/test/runner.js
@@ -38,9 +38,15 @@ function runTest(filename, done) {
     stdio: ['ignore', 1, 2]
   });
 
+  // test cases that are expected to exit with status code 1
+  const exceptionCases = [
+    'test-nexttick-exception.js',
+    'test-timer-exception.js'
+  ];
+
   p.once('close', function (statusCode) {
     const ok = function () {
-      if(filename === 'test-nexttick-exception.js') {
+      if(exceptionCases.indexOf(filename) > -1) {
         return statusCode === 1;
       }
       return statusCode === 0;

--- a/test/runner.js
+++ b/test/runner.js
@@ -39,7 +39,12 @@ function runTest(filename, done) {
   });
 
   p.once('close', function (statusCode) {
-    const ok = (statusCode === 0);
+    const ok = function () {
+      if(filename === 'test-nexttick-exception.js' && statusCode === 1) {
+        return true;
+      }
+      return statusCode === 0;
+    }();
 
     if (ok) {
       console.log(' ' + passed('ok'));

--- a/test/test-nexttick-didthrow.js
+++ b/test/test-nexttick-didthrow.js
@@ -40,7 +40,7 @@ process.once('exit', function () {
   assert.strictEqual(throwFlag, true);
   assert.deepEqual(eventOrder, [
     'init#-1 NextTickWrap', 'pre#-1',
-    'callback', 'exception',
-    'post#-1', 'destroy#-1'
+    'callback',
+    'post#-1', 'destroy#-1', 'exception'
   ]);
 });

--- a/test/test-nexttick-didthrow.js
+++ b/test/test-nexttick-didthrow.js
@@ -40,7 +40,7 @@ process.once('exit', function () {
   assert.strictEqual(throwFlag, true);
   assert.deepEqual(eventOrder, [
     'init#-1 NextTickWrap', 'pre#-1',
-    'callback',
-    'post#-1', 'destroy#-1', 'exception'
+    'callback', 'exception',
+    'post#-1', 'destroy#-1'
   ]);
 });

--- a/test/test-nexttick-exception.js
+++ b/test/test-nexttick-exception.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const assert = require('assert');
+const asyncHook = require('../');
+
+asyncHook.enable();
+
+process.nextTick(function () {
+  throw new Error('boom');
+});
+
+process.once('exit', function (statusCode) {
+  assert.equal(statusCode, 1);
+});

--- a/test/test-nexttick-exception.js
+++ b/test/test-nexttick-exception.js
@@ -1,14 +1,9 @@
 'use strict';
 
-const assert = require('assert');
 const asyncHook = require('../');
 
 asyncHook.enable();
 
 process.nextTick(function () {
   throw new Error('boom');
-});
-
-process.once('exit', function (statusCode) {
-  assert.equal(statusCode, 1);
 });

--- a/test/test-promise-timing.js
+++ b/test/test-promise-timing.js
@@ -31,6 +31,7 @@ new Promise(function (s) {
 .then();
 
 process.once('exit', function () {
+  process._rawDebug(eventOrder);
   assert.deepEqual(eventOrder, [
     'init#-1 TimeoutWrap',
     'init#-2 PromiseWrap',
@@ -42,13 +43,9 @@ process.once('exit', function () {
     'init#-4 TimeoutWrap',
     'post#-2',
     'destroy#-2',
-    'init#-5 PromiseWrap',
     'pre#-4',
     'post#-4',
     'destroy#-4',
-    'pre#-5',
-    'post#-5',
-    'destroy#-5',
     'destroy#-3'
   ]);
 });

--- a/test/test-promise-timing.js
+++ b/test/test-promise-timing.js
@@ -31,7 +31,6 @@ new Promise(function (s) {
 .then();
 
 process.once('exit', function () {
-  process._rawDebug(eventOrder);
   assert.deepEqual(eventOrder, [
     'init#-1 TimeoutWrap',
     'init#-2 PromiseWrap',

--- a/test/test-timer-exception.js
+++ b/test/test-timer-exception.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const asyncHook = require('../');
+
+asyncHook.enable();
+
+setTimeout(function () {
+  throw new Error('boom');
+});


### PR DESCRIPTION
Exceptions should be thrown and process shall exit if there is no listener for `uncaughtException` event.

I modified the way we run `post` and `destroy` hooks after an exception happens during next tick.