### PR TITLE
Avoid trigger de-opt in v8

### DIFF
--- a/patches/next-tick.js
+++ b/patches/next-tick.js
@@ -10,7 +10,7 @@ module.exports = function patch() {
   process.nextTick = function () {
     if (!state.enabled) return oldNextTick.apply(process, arguments);
 
-    const args = [];
+    const args = new Array(arguments.length);
     for (let i = 0; i < arguments.length; i++) {
       args[i] = arguments[i];
     }

--- a/patches/next-tick.js
+++ b/patches/next-tick.js
@@ -10,7 +10,10 @@ module.exports = function patch() {
   process.nextTick = function () {
     if (!state.enabled) return oldNextTick.apply(process, arguments);
 
-    const args = Array.from(arguments);
+    const args = [];
+    for (let i = 0; i < arguments.length; i++) {
+      args[i] = arguments[i];
+    }
     const callback = args[0];
 
     if (typeof callback !== 'function') {

--- a/patches/timers.js
+++ b/patches/timers.js
@@ -35,7 +35,7 @@ function patchTimer(hooks, state, setFn, clearFn, Handle, timerMap, singleCall) 
   timers[setFn] = function () {
     if (!state.enabled) return oldSetFn.apply(timers, arguments);
 
-    const args = [];
+    const args = new Array(arguments.length);
     for (let i = 0; i < arguments.length; i++) {
       args[i] = arguments[i];
     }

--- a/patches/timers.js
+++ b/patches/timers.js
@@ -35,7 +35,10 @@ function patchTimer(hooks, state, setFn, clearFn, Handle, timerMap, singleCall) 
   timers[setFn] = function () {
     if (!state.enabled) return oldSetFn.apply(timers, arguments);
 
-    const args = Array.from(arguments);
+    const args = [];
+    for (let i = 0; i < arguments.length; i++) {
+      args[i] = arguments[i];
+    }
     const callback = args[0];
 
     if (typeof callback !== 'function') {


### PR DESCRIPTION
The `Array.from(arguments` causes V8 to de-opt the function with a `Bad value context for arguments value`. Based on https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#what-is-safe-arguments-usage I found that copying the arguments using a regular for-loop avoids the de-opt.

This might seem like a micro-optimization, but since this is hooked on process.nextTick it makes a significant difference for our use-case at least.